### PR TITLE
Fixing initial distribution integer ids

### DIFF
--- a/easygdf/tests/test_easygdf.py
+++ b/easygdf/tests/test_easygdf.py
@@ -597,23 +597,24 @@ class TestEasyGDFSave(unittest.TestCase):
 
     def test_int_single_overflow(self):
         """
-        Confirms error is thrown if an integer larger than GDFs max size is passed
+        Confirms error is thrown if an integer larger than GDFs max size is passed. Test this for both positive and
+        negative values.  The positive integer should be cast to uint32 and the negative to int32.
 
         :return:
         """
-
-        # If the system doesn't use 64 bit integers, just pass
-
-        # Make the data
-        blocks = [
-            {'name': 'ID', 'value': 0x7FFFFFFF17, 'children': []}
-        ]
-
-        # Save it
-        test_file = os.path.join(tempfile.gettempdir(), "save_int_single_overflow.gdf")
-        with open(test_file, "wb") as f:
+        # Test overflowing the negative value
+        with open(os.path.join(tempfile.gettempdir(), "save_int_single_overflow_1.gdf"), "wb") as f:
             with self.assertRaises(ValueError):
-                easygdf.save(f, blocks)
+                easygdf.save(f, [{'name': 'ID', 'value': -0x80000000, 'children': []}, ])
+
+        # Confirm something bigger than the max int32 but smaller than the max uint32 doesn't overflow
+        with open(os.path.join(tempfile.gettempdir(), "save_int_single_overflow_2.gdf"), "wb") as f:
+            easygdf.save(f, [{'name': 'ID', 'value': 0x80000000, 'children': []}, ])
+
+        # Test overflowing the positive value
+        with open(os.path.join(tempfile.gettempdir(), "save_int_single_overflow_3.gdf"), "wb") as f:
+            with self.assertRaises(ValueError):
+                easygdf.save(f, [{'name': 'ID', 'value': 0x100000000, 'children': []}, ])
 
     def test_int_array_overflow(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,10 @@ from setuptools import setup
 
 setup(
     name='easygdf',
-    version='2.0.6',
+    version='2.0.7',
     description='A python library to make working with GDF files a breeze.',
     long_description='A python library to make working with GDF files a breeze.  Check out our project on [github](https://github.com/electronsandstuff/easygdf)!',
-    long_description_content_type = 'text/markdown',
+    long_description_content_type='text/markdown',
     author='Christopher M. Pierce',
     author_email='contact@chris-pierce.com',
     packages=['easygdf', 'easygdf.tests'],


### PR DESCRIPTION
This PR adds casting support for 64 integers into 32 bit integers.  64 bit integers appear to not be supported in GPT and related software.  This was raised in #5.  The solution is to cast all compatible values down to their 32 bit versions.  When there is an overflow, a ValueError is raised.  The version was also bumped up and it appears to pass all unit tests.