### PR TITLE
Avoid Imports in Tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,4 +25,4 @@ jobs:
         pip install .
     - name: Run the tests
       run: |
-        python -m unittest
+        python -m unittest discover tests

--- a/tests/test_easygdf.py
+++ b/tests/test_easygdf.py
@@ -6,7 +6,9 @@ import unittest
 import numpy as np
 import easygdf
 
-from .utils import load_test_resource
+
+def load_test_resource(path):
+    return open(os.path.join(os.path.dirname(os.path.realpath(__file__)), path), "rb")
 
 
 class TestEasyGDFHelpers(unittest.TestCase):

--- a/tests/test_initial_distribution.py
+++ b/tests/test_initial_distribution.py
@@ -6,7 +6,9 @@ import numpy as np
 
 import easygdf
 
-from .utils import load_test_resource
+
+def load_test_resource(path):
+    return open(os.path.join(os.path.dirname(os.path.realpath(__file__)), path), "rb")
 
 
 class TestEasyGDFInitialDistribution(unittest.TestCase):

--- a/tests/test_screens_touts.py
+++ b/tests/test_screens_touts.py
@@ -4,7 +4,9 @@ import tempfile
 import unittest
 import easygdf
 
-from .utils import load_test_resource
+
+def load_test_resource(path):
+    return open(os.path.join(os.path.dirname(os.path.realpath(__file__)), path), "rb")
 
 
 class TestEasyGDFScreensTouts(unittest.TestCase):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,0 @@
-import os
-
-
-def load_test_resource(path):
-    return open(os.path.join(os.path.dirname(os.path.realpath(__file__)), path), "rb")


### PR DESCRIPTION
This PR removes relative imports from tests. Some platforms seem to not handle this well.